### PR TITLE
Refactor/session lock management

### DIFF
--- a/Dummy/ConsoleRenderer.cpp
+++ b/Dummy/ConsoleRenderer.cpp
@@ -1,4 +1,4 @@
-﻿#include "Global.h"
+#include "Global.h"
 
 #include <windows.h>
 #include <thread>
@@ -189,7 +189,7 @@ void s_Draw(SHORT x, SHORT y, WCHAR c)
 void ConsoleRenderer::DrawObjects()
 {
 	UINT32 countObjects = 0;
-	UINT32 keys[128];
+	UINT32 keys[1024];
 
 	Vector3 cameraPos = g_pCamera->GetPosition();
 

--- a/Dummy/DummyManager.h
+++ b/Dummy/DummyManager.h
@@ -31,7 +31,7 @@ public:
 	void Tick();
 
 private:
-	const int MAX_DUMMY_COUNT = 150;
+	const int MAX_DUMMY_COUNT = 100;
 	int _countDummy = 0;
 	Dummy* _pDummyMaster = nullptr;
 

--- a/Dummy/DummyManager.h
+++ b/Dummy/DummyManager.h
@@ -31,7 +31,7 @@ public:
 	void Tick();
 
 private:
-	const int MAX_DUMMY_COUNT = 100;
+	const int MAX_DUMMY_COUNT = 150;
 	int _countDummy = 0;
 	Dummy* _pDummyMaster = nullptr;
 

--- a/Dummy/Game.cpp
+++ b/Dummy/Game.cpp
@@ -139,7 +139,7 @@ void s_ApplyKeyboardEvents(ULONGLONG tickDiff)
 void s_PreProcessNextMovements()
 {
 	// 유저와 네트워크 입력에 따라 객체의 이동 상태 변경에 대응하기 위함
-	UINT32 keys[128];
+	UINT32 keys[1024];
 	UINT32 countKeys;
 
 	int objectKindEnumMax = (int)GAME_OBJECT_TYPE_OBSTACLE;
@@ -159,7 +159,7 @@ void s_PreProcessNextMovements()
 
 void s_ApplyObjectLogic(ULONGLONG tickDiff)
 {
-	UINT32 keys[128];
+	UINT32 keys[1024];
 	UINT32 countKeys;
 
 	int objectKindEnumMax = (int)GAME_OBJECT_TYPE_OBSTACLE;

--- a/NetCore/.editorconfig
+++ b/NetCore/.editorconfig
@@ -9,6 +9,9 @@ cpp_generate_documentation_comments = xml
 
 # Visual C++ Formatting settings
 
+indent_style = tab
+indent_size = tab
+
 cpp_indent_braces = false
 cpp_indent_multi_line_relative_to = innermost_parenthesis
 cpp_indent_within_parentheses = indent

--- a/NetCore/NetCore.cpp
+++ b/NetCore/NetCore.cpp
@@ -135,7 +135,14 @@ UINT32 NetCore::ConnectTo(const char* ip, int port)
 		return 0;
 	}
 
-	pSession->RegisterReceive();
+	ENetCoreResult receiveStartResult = _sessionManager.BeginReceive(pSession->GetID());
+	if (receiveStartResult == NC_SUCCESS) {
+		// WriteSessionEvent(pSession->GetID(), ESessionEvent::CREATE_PASSIVE_CLIENT, threadID); // 
+	}
+	else {
+		_sessionManager.RemoveSession(pSession->GetID(), COMPLETION_RECV_ERROR);
+		return INVALID_SESSION_ID;
+	}
 
 	return pSession->GetID();
 }
@@ -372,8 +379,11 @@ void NetCore::OnAccept(AcceptIoOperationData* data, int threadId)
 		0
 	);
 
-	bool isSuccessed = pNewSession->RegisterReceive();
-	if (isSuccessed) {
+	// BeginReceive
+
+	ENetCoreResult receiveStartResult = _sessionManager.BeginReceive(pNewSession->GetID());
+	if (receiveStartResult == NC_SUCCESS) {
+
 		WriteSessionEvent(pNewSession->GetID(), ESessionEvent::CREATE_PASSIVE_CLIENT, threadId);
 	}
 	else {

--- a/NetCore/NetCore.cpp
+++ b/NetCore/NetCore.cpp
@@ -257,10 +257,14 @@ unsigned WINAPI NetCore::ThreadIoCompletion(LPVOID pParam)
 			IoOperationData* pData = CONTAINING_RECORD(pOverlapped, IoOperationData, wol);
 			if (pData->operation == IoOperationData::RECEIVE)
 			{
+				// SessionManager->OnReceive(dwTransferredSize, sessionID)
 				// recieve 완료
 				if (dwTransferredSize == 0)
 				{
 					// 클라이언트의 종료
+					// SessionManager->OnReceiveDisconnect()
+
+					
 					ESessionRefResult res = pSession->ReduceReference(ESessionRefParam::SESSION_REF_DECREASE_RECV);
 					if (res == SESSION_REF_DEACTIVATE) {
 						SHORT id = pSession->GetID();
@@ -271,6 +275,8 @@ unsigned WINAPI NetCore::ThreadIoCompletion(LPVOID pParam)
 				else
 				{
 					// 데이터를 수신한 경우
+					// SessionManager->OnReceive(dwTransferredSize, sessionID, threadID);
+
 					pSession->OnReceive(dwTransferredSize);
 					
 					NetMessage* pNetMessage = pSession->GetReceiveNetMessageOrNull();
@@ -287,6 +293,7 @@ unsigned WINAPI NetCore::ThreadIoCompletion(LPVOID pParam)
 			}
 			else if (pData->operation == IoOperationData::SEND)
 			{
+				// sessionManager->OnSendComplete(sessionID);
 				pSession->OnSendComplete();
 			}
 			else if (pData->operation == IoOperationData::ACCEPT)
@@ -299,6 +306,7 @@ unsigned WINAPI NetCore::ThreadIoCompletion(LPVOID pParam)
 		}
 		else
 		{
+			// 각종 오류 상황
 			if (pSession == NULL || pOverlapped == NULL) {
 				// 발생하면 안되는 경우
 				__debugbreak();
@@ -306,6 +314,7 @@ unsigned WINAPI NetCore::ThreadIoCompletion(LPVOID pParam)
 
 			IoOperationData* pData = CONTAINING_RECORD(pOverlapped, IoOperationData, wol);
 			if (pData->operation == IoOperationData::RECEIVE) {
+				// Receiving 해제, 
 				ESessionRefResult res = pSession->ReduceReference(ESessionRefParam::SESSION_REF_DECREASE_RECV);
 				if (res == SESSION_REF_DEACTIVATE) {
 					SHORT id = pSession->GetID();
@@ -315,6 +324,7 @@ unsigned WINAPI NetCore::ThreadIoCompletion(LPVOID pParam)
 				continue;
 			}
 			else if (pData->operation == IoOperationData::SEND) {
+				// Sending 해제, 
 				ESessionRefResult res = pSession->ReduceReference(ESessionRefParam::SESSION_REF_DECREASE_SEND);
 				if (res == SESSION_REF_DEACTIVATE) {
 					SHORT id = pSession->GetID();

--- a/NetCore/NetCore.h
+++ b/NetCore/NetCore.h
@@ -10,6 +10,7 @@ struct ThreadArgInfo
 {
 	UINT32 threadID = 0;
 	NetCore* pNetCore = nullptr;
+	SessionManager* pSessionManager = nullptr;
 };
 
 struct AcceptIoOperationData
@@ -47,7 +48,7 @@ private:
 	void InitiateAllocation();
 	void TerminateAllocation();
 
-	void WriteSessionEvent(UINT32 sessionId, ESessionEvent sessionEvent, int threadId);
+	void WriteSessionEvent(SessionID sessionId, ESessionEvent sessionEvent, int threadId);
 
 	// 임시
 	void WaitNetCore();

--- a/NetCore/NetCoreAliases.h
+++ b/NetCore/NetCoreAliases.h
@@ -2,4 +2,5 @@
 
 
 using SessionID = unsigned int;
+using SessionFlag = unsigned int;
 const unsigned int INVALID_SESSION_ID = 0xFFFFFFFF;

--- a/NetCore/NetCoreCommon.h
+++ b/NetCore/NetCoreCommon.h
@@ -31,3 +31,13 @@ enum ESessionRemoveReason
 	FORCE_REMOVE
 };
 
+enum ENetCoreResult
+{
+	NC_SUCCESS,
+	NC_ERROR_REQUEST_FAIL,
+	NC_ERROR_SESSION_REMOVED,
+	NC_NONE
+};
+
+
+

--- a/NetCore/NetMessageQueue.cpp
+++ b/NetCore/NetMessageQueue.cpp
@@ -20,9 +20,9 @@ void NetMessageQueue::WriteNetMessage(UINT32 sessionID, NetMessage* pMessage)
 	size_t sizeNetMessage = pMessage->header.length + sizeof(NetMessage::header);
 	LONG count = InterlockedExchangeAdd(&_count, 1);
 	LONG writeIndex = InterlockedExchangeAdd(&_writeIndex, sizeof(sessionID) + sizeNetMessage);
-	// Todo: 여기 count가 문제가 생길 소지가 있음. 위 두 개가 원자적으로 동작하지 않으므로. 그런데 어차피 한 큐에 전부다 못 넣으면 이미 망한다는 마인드긴 함. 
 
-	// 처리할 수 있는 용량이 초과됨. 버퍼를 늘리는게 가장 좋은 방법. 릴리즈에서도 크래시가 생기게 해버리는게 나을지도.
+	// 처리할 수 있는 용량이 초과됨. 버퍼를 늘리는게 가장 좋은 방법.
+	// 게임에서 사용하는 패킷의 양은 대개 정해져있으므로, 아래 경우는 오류의 상황이라 간주해도 무방. 
 	assert(writeIndex < NET_CONCURRENT_MESSAGE_QUEUE_MAX_SIZE);
 
 	BYTE* pWrite = _msgBuffer + writeIndex;

--- a/NetCore/Session.h
+++ b/NetCore/Session.h
@@ -18,11 +18,11 @@ enum ESessionRefResult
 	SESSION_REF_STOP_SENDING,
 };
 
-
+// SessionManager 클래스에서 관리돼야 하며, 외부에서 직접 접근할 시 쓰레드 안전을 보장하지 않음.
 class Session
 {
 public:
-	Session(SOCKET socket, SHORT id);
+	Session(SOCKET socket, SessionID id);
 	~Session();
 
 	void Initiate();
@@ -39,24 +39,19 @@ public:
 	// 여기서 얻은 NetMessage 포인터에 대해 메모리 할당 해제를 하면 안됨.
 	NetMessage* GetReceiveNetMessageOrNull();
 
-	void SendLock(BYTE* msg, UINT32 len);
-
 	// 반드시 외부에서 lock을 통해 쓰레드안전하게 만든 후 호출해야 함
 	void Send(BYTE* msg, UINT32 len);
 	
 	void OnSendComplete();
 
-	ESessionRefResult ReduceReference(ESessionRefParam param);
-
-
-	void Lock();
-	void Unlock();
 	
 
-	static void HandleWSAError(DWORD errorCode, UINT32 sessionId);
+	ESessionRefResult ReduceReference(ESessionRefParam param);
+
+	static void HandleWSAError(DWORD errorCode, SessionID sessionId);
 
 private:
-	UINT32 _id = 0;
+	SessionID _id = 0;
 	SOCKET _socket = 0;
 
 	Stream* _receiveStream = nullptr;

--- a/NetCore/Session.h
+++ b/NetCore/Session.h
@@ -18,9 +18,12 @@ enum ESessionRefResult
 	SESSION_REF_STOP_SENDING,
 };
 
+class SessionManager;
+
 // SessionManager 클래스에서 관리돼야 하며, 외부에서 직접 접근할 시 쓰레드 안전을 보장하지 않음.
 class Session
 {
+	friend SessionManager;
 public:
 	Session(SOCKET socket, SessionID id);
 	~Session();
@@ -33,17 +36,17 @@ public:
 
 	void Disconnect();
 
-	void RegisterReceive();
+	DWORD RegisterReceive();
 	void OnReceive(DWORD length);
 
 	// 여기서 얻은 NetMessage 포인터에 대해 메모리 할당 해제를 하면 안됨.
 	NetMessage* GetReceiveNetMessageOrNull();
 
 	// 반드시 외부에서 lock을 통해 쓰레드안전하게 만든 후 호출해야 함
-	void Send(BYTE* msg, UINT32 len);
+	bool Send(BYTE* msg, UINT32 len);
 	
 	void OnSendComplete();
-
+	bool TryResend();
 	
 
 	ESessionRefResult ReduceReference(ESessionRefParam param);
@@ -69,6 +72,6 @@ private:
 	BOOL _isSending = false;
 	BOOL _isRecving = true;
 
-	void RegisterSend();
+	DWORD RegisterSend();
 };
 

--- a/NetCore/Session.h
+++ b/NetCore/Session.h
@@ -70,7 +70,6 @@ private:
 	WSABUF _sendWsaBuf = { 0, };
 	IoOperationData _sendIoData = { 0, };
 
-	SRWLOCK _srwLock = SRWLOCK_INIT;
 	
 	BOOL _isSending = false;
 	BOOL _isRecving = true;

--- a/NetCore/SessionManager.h
+++ b/NetCore/SessionManager.h
@@ -37,6 +37,8 @@ public:
 
 	void DisconnectAllSessions();
 
+	ENetCoreResult BeginReceive(SessionID id);
+
 	ENetCoreResult SendMessageTo(SessionID sessionID, BYTE* msg, UINT32 length);
 
 	ENetCoreResult OnSendComplete(SessionID sessionID);

--- a/NetCore/SessionManager.h
+++ b/NetCore/SessionManager.h
@@ -31,6 +31,12 @@ public:
 
 	void SendMessageTo(SessionID sessionID, BYTE* msg, UINT32 length);
 
+	// Resend or ..
+	bool OnSendComplete(SessionID sessionID);
+	bool TryRemoveSessionOnReceive(SessionID sessionID);
+	bool TryRemoveSessionOnSend(SessionID sessionID);
+
+
 private:
 	SRWLOCK _tableLock = SRWLOCK_INIT;
 	SessionGuard _sessionTable[MAX_NUM_SESSIONS];

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Windows 서버에서 동작하는 고성능 Stateful MMORPG 서버
 
 ## 게임 엔진
 
-![게임엔진루프](/pictures/게임엔진루프.png)
+![게임엔진루프](pictures/게임엔진루프.png)
 
 기본 루프를 서버, 클라이언트, 더미가 공유하며, 사용 시 약간의 차이가 있음.
 
@@ -70,21 +70,21 @@ Windows 서버에서 동작하는 고성능 Stateful MMORPG 서버
 - 핸들 등의 통신 핵심 리소스를 외부에 직접 노출하지 않음.
 - 받은 패킷을 NetMessage로 변경 후 공통 Buffer에 쌓으며, 읽어서 처리하는 것은 main의 몫.
 
-![Receive 과정](/pictures/NetCoreReceive.png)
+![Receive 과정](pictures/NetCoreReceive.png)
 
 Receive 과정
 
-![Send 과정(성공 시)](/pictures/NetCoreSend성공.png)
+![Send 과정(성공 시)](pictures/NetCoreSend성공.png)
 
 Send 과정(성공 시)
 
-![Send 과정(이미 해당 Session에 대해 Send중일 시)](/pictures/NetCoreSend실행중.png)
+![Send 과정(이미 해당 Session에 대해 Send중일 시)](pictures/NetCoreSend실행중.png)
 
 Send 과정(이미 해당 Session에 대해 Send중일 시)
 
 ### Sentinel (서버)
 
-![전체구조.png](/pictures/서버구조.png)
+![전체구조.png](pictures/서버구조.png)
 
 구름 모양은 쓰레드를 의미
 
@@ -92,7 +92,7 @@ Send 과정(이미 해당 Session에 대해 Send중일 시)
 
 ### DB
 
-![스크린샷 2025-02-03 173434.png](/pictures/DB구조.png)
+![스크린샷 2025-02-03 173434.png](pictures/DB구조.png)
 
 유저의 ID, PW, 점수가 저장돼있음.
 
@@ -104,15 +104,15 @@ Send 과정(이미 해당 Session에 대해 Send중일 시)
 
 이동 시작, 종료, 이동 중을 클라이언트가 서버로 전달.
 
-![이동 이벤트 발생 시 플래그 전달](/pictures/이동1.png)
+![이동 이벤트 발생 시 플래그 전달](pictures/이동1.png)
 
 이동 이벤트 발생 시 플래그 전달
 
-![클라이언트와 서버 각각 이동 처리](/pictures/이동2.png)
+![클라이언트와 서버 각각 이동 처리](pictures/이동2.png)
 
 클라이언트와 서버 각각 이동 처리
 
-![이동 종료 시 서버에서 수용 가능한 범위인지 판단해서 처리. 이동 중 패킷도 같은 동작을 함.](/pictures/이동3.png)
+![이동 종료 시 서버에서 수용 가능한 범위인지 판단해서 처리. 이동 중 패킷도 같은 동작을 함.](pictures/이동3.png)
 
 이동 종료 시 서버에서 수용 가능한 범위인지 판단해서 처리. 이동 중 패킷도 같은 동작을 함.
 
@@ -120,13 +120,13 @@ Send 과정(이미 해당 Session에 대해 Send중일 시)
 
 생성은 서버가 지시, 클라이언트는 요청만 함
 
-![투사체1.png](/pictures/투사체1.png)
+![투사체1.png](pictures/투사체1.png)
 
-![투사체2.png](/pictures/투사체2.png)
+![투사체2.png](pictures/투사체2.png)
 
-![투사체3.png](/pictures/투사체3.png)
+![투사체3.png](pictures/투사체3.png)
 
-![투사체4.png](/pictures/투사체4.png)
+![투사체4.png](pictures/투사체4.png)
 
 ---
 

--- a/Sentinel/GameServer.cpp
+++ b/Sentinel/GameServer.cpp
@@ -293,7 +293,7 @@ void s_ProcessDBQueryResults()
 
 void s_PreProcessNextMovements()
 {
-	UINT32 keys[128];
+	UINT32 keys[1024];
 	UINT32 countKeys;
 
 	int objectKindEnumMax = (int)GAME_OBJECT_TYPE_OBSTACLE;

--- a/Tank/ConsoleRenderer.cpp
+++ b/Tank/ConsoleRenderer.cpp
@@ -1,4 +1,4 @@
-﻿#include "Global.h"
+#include "Global.h"
 
 #include <windows.h>
 #include <thread>
@@ -189,7 +189,7 @@ void s_Draw(SHORT x, SHORT y, WCHAR c)
 void ConsoleRenderer::DrawObjects()
 {
 	UINT32 countObjects = 0;
-	UINT32 keys[128];
+	UINT32 keys[1024];
 
 	Vector3 cameraPos = g_pCamera->GetPosition();
 

--- a/Tank/Game.cpp
+++ b/Tank/Game.cpp
@@ -140,7 +140,7 @@ void s_ApplyKeyboardEvents(ULONGLONG tickDiff)
 void s_PreProcessNextMovements()
 {
 	// 유저와 네트워크 입력에 따라 객체의 이동 상태 변경에 대응하기 위함
-	UINT32 keys[128];
+	UINT32 keys[1024];
 	UINT32 countKeys;
 
 	int objectKindEnumMax = (int)GAME_OBJECT_TYPE_OBSTACLE;
@@ -160,7 +160,7 @@ void s_PreProcessNextMovements()
 
 void s_ApplyObjectLogic(ULONGLONG tickDiff)
 {
-	UINT32 keys[128];
+	UINT32 keys[1024];
 	UINT32 countKeys;
 
 	int objectKindEnumMax = (int)GAME_OBJECT_TYPE_OBSTACLE;


### PR DESCRIPTION
세션 락 및 상태 관리체계 변경
SessionManager에서 SessionTable을 만들고, sending, receiving, active, 상태와 session ptr을 함께 관리함. 
다른 세션은 멀티쓰레드 IO가 가능하게 변경, Recv/Send도 가능하게 변경.